### PR TITLE
Refresh only lines instead of full screen

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -16,6 +16,7 @@ pub struct Editor {
     mode: Mode,
 }
 
+#[derive(Clone)]
 /// Mode of the editor
 pub enum Mode {
     /// Normal mode
@@ -102,7 +103,7 @@ impl Editor {
                 let mut lines_to_refresh = HashSet::new();
                 self.view.insert_new_line();
                 lines_to_refresh.insert(y as u16);
-                lines_to_refresh.insert((y - 1) as u16);
+                lines_to_refresh.insert((y + 1) as u16);
                 RefreshOrder::Lines(lines_to_refresh)
             }
             Command::Delete => {
@@ -114,11 +115,11 @@ impl Editor {
                 RefreshOrder::Lines(lines_to_refresh)
             }
             Command::CommandBlock(cmds) => {
-                let mut refr: RefreshOrder;
+                let mut refr: RefreshOrder = RefreshOrder::StatusBar;
                 let mut lines_to_refresh = HashSet::new();
                 cmds.into_iter().for_each(|cmd| {
                     refr = self.execute(cmd);
-                    match refr {
+                    match &refr {
                         RefreshOrder::CursorPos => {}
                         RefreshOrder::Lines(lines) => {
                             lines_to_refresh.extend(lines);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -119,20 +119,14 @@ impl Editor {
             }
             Command::CommandBlock(cmds) => {
                 let mut refr: RefreshOrder = RefreshOrder::StatusBar;
-                let mut lines_to_refresh = HashSet::new();
+                let mut lines_to_refresh: HashSet<u16> = HashSet::new();
                 cmds.into_iter().for_each(|cmd| {
                     refr = self.execute(cmd);
                     match &refr {
-                        RefreshOrder::CursorPos => {}
                         RefreshOrder::Lines(lines) => {
                             lines_to_refresh.extend(lines);
                         }
-                        RefreshOrder::StatusBar => {}
-                        RefreshOrder::AllLines => {
-                            for i in 0..self.view.height {
-                                lines_to_refresh.insert(i as u16);
-                            }
-                        }
+                        _ => {}
                     }
                 });
                 refr

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,11 @@
 use std::{collections::HashSet, process::exit};
 
-use crate::{command::Command, file::File, tui::{Tui, StatusBar}, view::View};
+use crate::{
+    command::Command,
+    file::File,
+    tui::{StatusBar, Tui},
+    view::View,
+};
 use termion::input::TermRead;
 
 /// Editor structure
@@ -83,8 +88,12 @@ impl Editor {
                 RefreshOrder::AllLines
             }
             Command::Move(x, y) => {
-                self.view.navigate(x, y);
-                RefreshOrder::CursorPos
+                let scroll = self.view.navigate(x, y);
+                if scroll {
+                    RefreshOrder::AllLines
+                } else {
+                    RefreshOrder::CursorPos
+                }
             }
             Command::Save => {
                 self.save();
@@ -175,10 +184,10 @@ impl Editor {
                             sb.mode = self.mode.clone();
                             self.tui.draw_status_bar(&sb, height, width)
                         }
-                        RefreshOrder::CursorPos => self.tui.draw_view(&self.view, &self.file_name, &self.mode),
-                        RefreshOrder::Lines(lines) => {
-                            self.tui.refresh_lines(&self.view, lines)
+                        RefreshOrder::CursorPos => {
+                            self.tui.draw_view(&self.view, &self.file_name, &self.mode)
                         }
+                        RefreshOrder::Lines(lines) => self.tui.refresh_lines(&self.view, lines),
                     }
                 }
             }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -80,7 +80,7 @@ impl Editor {
         match cmd {
             Command::Quit => {
                 self.terminate();
-                RefreshOrder::ALLLines
+                RefreshOrder::AllLines
             }
             Command::Move(x, y) => {
                 self.view.navigate(x, y);
@@ -128,7 +128,7 @@ impl Editor {
                             lines_to_refresh.extend(lines);
                         }
                         RefreshOrder::StatusBar => {}
-                        RefreshOrder::ALLLines => {
+                        RefreshOrder::AllLines => {
                             for i in 0..self.view.height {
                                 lines_to_refresh.insert(i as u16);
                             }
@@ -172,7 +172,7 @@ impl Editor {
                 if let Ok(cmd) = Command::parse(c, &self.mode) {
                     let refresh_order = self.execute(cmd);
                     match refresh_order {
-                        RefreshOrder::ALLLines => {
+                        RefreshOrder::AllLines => {
                             self.tui.draw_view(&self.view, &self.file_name, &self.mode)
                         }
                         RefreshOrder::StatusBar => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -105,8 +105,9 @@ impl Editor {
                 let y = self.view.cursor.1;
                 let mut lines_to_refresh = HashSet::new();
                 self.view.insert_new_line();
-                lines_to_refresh.insert(y as u16);
-                lines_to_refresh.insert((y + 1) as u16);
+                for i in y..self.view.height {
+                    lines_to_refresh.insert(i as u16);
+                }
                 RefreshOrder::Lines(lines_to_refresh)
             }
             Command::Delete => {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -104,7 +104,10 @@ impl Editor {
                 RefreshOrder::StatusBar
             }
             Command::Insert(c) => {
-                self.view.insert(c);
+                let scroll = self.view.insert(c);
+                if scroll {
+                    return RefreshOrder::AllLines;
+                }
                 let y = self.view.cursor.1;
                 let mut lines_to_refresh = HashSet::new();
                 lines_to_refresh.insert(y as u16);

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -29,7 +29,7 @@ pub enum RefreshOrder {
     CursorPos,
     Lines(HashSet<u16>),
     StatusBar,
-    ALLLines,
+    AllLines,
 }
 
 impl Editor {

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -113,9 +113,13 @@ impl Editor {
             Command::InsertNewLine => {
                 let y = self.view.cursor.1;
                 let mut lines_to_refresh = HashSet::new();
-                self.view.insert_new_line();
-                for i in y..self.view.height {
-                    lines_to_refresh.insert(i as u16);
+                let scroll = self.view.insert_new_line();
+                if scroll {
+                    return RefreshOrder::AllLines;
+                } else {
+                    for i in y..self.view.height {
+                        lines_to_refresh.insert(i as u16);
+                    }
                 }
                 RefreshOrder::Lines(lines_to_refresh)
             }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -86,7 +86,10 @@ impl Editor {
                 self.view.navigate(x, y);
                 RefreshOrder::CursorPos
             }
-            Command::Save => RefreshOrder::StatusBar,
+            Command::Save => {
+                self.save();
+                RefreshOrder::StatusBar
+            }
             Command::ToggleMode => {
                 self.toggle_mode();
                 RefreshOrder::StatusBar

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,4 +1,4 @@
-use std::process::exit;
+use std::{collections::HashSet, process::exit};
 
 use crate::{command::Command, file::File, tui::Tui, view::View};
 use termion::input::TermRead;
@@ -22,6 +22,13 @@ pub enum Mode {
     Normal,
     /// Insert mode
     Insert,
+}
+
+pub enum RefreshOrder {
+    CursorPos,
+    Lines(HashSet<u16>),
+    StatusBar,
+    ALLLines,
 }
 
 impl Editor {
@@ -68,16 +75,64 @@ impl Editor {
     /// - ToggleMode: toogle editor mode
     /// - Insert: insert a character
     /// - Delete: delete a character
-    fn execute(&mut self, cmd: Command) {
+    fn execute(&mut self, cmd: Command) -> RefreshOrder {
         match cmd {
-            Command::Quit => self.terminate(),
-            Command::Move(x, y) => self.view.navigate(x, y),
-            Command::Save => self.save(),
-            Command::ToggleMode => self.toggle_mode(),
-            Command::Insert(c) => self.view.insert(c),
-            Command::InsertNewLine => self.view.insert_new_line(),
-            Command::Delete => self.view.delete(),
-            Command::CommandBlock(cmds) => cmds.into_iter().for_each(|cmd| self.execute(cmd)),
+            Command::Quit => {
+                self.terminate();
+                RefreshOrder::ALLLines
+            }
+            Command::Move(x, y) => {
+                self.view.navigate(x, y);
+                RefreshOrder::CursorPos
+            }
+            Command::Save => RefreshOrder::StatusBar,
+            Command::ToggleMode => {
+                self.toggle_mode();
+                RefreshOrder::StatusBar
+            }
+            Command::Insert(c) => {
+                self.view.insert(c);
+                let y = self.view.cursor.1;
+                let mut lines_to_refresh = HashSet::new();
+                lines_to_refresh.insert(y as u16);
+                RefreshOrder::Lines(lines_to_refresh)
+            }
+            Command::InsertNewLine => {
+                let y = self.view.cursor.1;
+                let mut lines_to_refresh = HashSet::new();
+                self.view.insert_new_line();
+                lines_to_refresh.insert(y as u16);
+                lines_to_refresh.insert((y - 1) as u16);
+                RefreshOrder::Lines(lines_to_refresh)
+            }
+            Command::Delete => {
+                self.view.delete();
+                let y = self.view.cursor.1;
+                let mut lines_to_refresh = HashSet::new();
+                lines_to_refresh.insert(y as u16);
+                lines_to_refresh.insert((y + 1) as u16);
+                RefreshOrder::Lines(lines_to_refresh)
+            }
+            Command::CommandBlock(cmds) => {
+                let mut refr: RefreshOrder;
+                let mut lines_to_refresh = HashSet::new();
+                cmds.into_iter().for_each(|cmd| {
+                    refr = self.execute(cmd);
+                    match refr {
+                        RefreshOrder::CursorPos => {}
+                        RefreshOrder::Lines(lines) => {
+                            lines_to_refresh.extend(lines);
+                        }
+                        RefreshOrder::StatusBar => {}
+                        RefreshOrder::ALLLines => {
+                            for i in 0..self.view.height {
+                                lines_to_refresh.insert(i as u16);
+                            }
+                        }
+                    }
+                });
+                refr
+            }
         }
     }
 
@@ -95,7 +150,8 @@ impl Editor {
         let (width, height) = self.tui.get_term_size();
         // height - 1 to leave space for the status bar
         // width - 3 to leave space for the line numbers
-        self.view.resize((height - 1) as usize, (width - 4) as usize);
+        self.view
+            .resize((height - 1) as usize, (width - 4) as usize);
 
         // draw initial view
         self.tui.clear();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -136,6 +136,9 @@ impl Editor {
                         RefreshOrder::Lines(lines) => {
                             lines_to_refresh.extend(lines);
                         }
+                        RefreshOrder::CursorPos | RefreshOrder::StatusBar => {
+                            refr = RefreshOrder::AllLines
+                        } // on command, we can refresh all lines as it may be undo / redo
                         _ => {}
                     }
                 });

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -124,11 +124,15 @@ impl Editor {
                 RefreshOrder::Lines(lines_to_refresh)
             }
             Command::Delete => {
-                self.view.delete();
+                let scroll = self.view.delete();
+                if scroll {
+                    return RefreshOrder::AllLines;
+                }
                 let y = self.view.cursor.1;
                 let mut lines_to_refresh = HashSet::new();
-                lines_to_refresh.insert(y as u16);
-                lines_to_refresh.insert((y + 1) as u16);
+                for i in y..self.view.height {
+                    lines_to_refresh.insert(i as u16);
+                } 
                 RefreshOrder::Lines(lines_to_refresh)
             }
             Command::CommandBlock(cmds) => {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -119,19 +119,16 @@ impl Tui {
         self.clear();
         let height = view.height;
         let width = view.width;
-        for line in 0..height {
+        for line in 1..height + 1 {
             self.draw_line_numbers(line);
-            write!(
-                self.stdout,
-                "{}{}",
-                cursor::Goto(LINE_NUMBER_WIDTH + 1, (line + 1) as u16),
-                view.get_line(line)
-            )
-            .unwrap_or_default();
+            write!(self.stdout, "{}", view.get_line(line - 1)).unwrap_or_default();
         }
         // print the status bar
-        let name = file_name.clone().unwrap_or("New File".to_string());
-        self.draw_status_bar(name, mode, height as u16, width as u16);
+        let sb = StatusBar {
+            file_name: file_name.clone().unwrap_or("NewFile".to_string()),
+            mode: mode.clone(),
+        };
+        self.draw_status_bar(&sb, height as u16, width as u16);
         print!("{}", cursor::Goto(1, 1));
 
         // move the cursor to the correct position

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -100,17 +100,19 @@ impl Tui {
     /// The line numbers are displayed at the left of the screen in blue
     pub fn draw_line_numbers(&mut self, line: usize) {
         let number = format!("{:3} ", line);
-
         write!(
             self.stdout,
-            "{}{}{}{}{}",
-            cursor::Goto(1, (line + 1) as u16),
+            "{}{}{}{}{}{}{}",
+            cursor::Goto(1, (line) as u16),
+            clear::CurrentLine,
             color::Fg(color::Blue),
             number,
-            cursor::Goto(LINE_NUMBER_WIDTH, (line + 1) as u16),
+            cursor::Goto(LINE_NUMBER_WIDTH, (line) as u16),
             color::Fg(color::Reset),
+            cursor::Goto(LINE_NUMBER_WIDTH + 1, (line) as u16), // release the cursor where to write the line
         )
         .unwrap_or_default();
+        self.stdout.flush().unwrap_or_default();
     }
 
     /// Draw the view on the screen

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -68,18 +68,12 @@ impl Tui {
     /// Draw the status bar
     /// The status bar is displayed at the bottom of the screen
     /// It contains the current mode and the file name
-    pub fn draw_status_bar(
-        &mut self,
-        file_name: String,
-        mode: &Mode,
-        height: u16,
-        width: u16,
-    ) {
-        let mode: String = match mode {
+    pub fn draw_status_bar(&mut self, status_bar: &StatusBar, height: u16, width: u16) {
+        let mode: String = match status_bar.mode {
             Mode::Normal => "NORMAL ".to_string(),
             Mode::Insert => "INSERT ".to_string(),
         };
-        let padding = width - file_name.len() as u16 - mode.len() as u16;
+        let padding = width - status_bar.file_name.len() as u16 - mode.len() as u16;
         write!(
             self.stdout,
             "{}{}{}{}{}{}{}{}{}",
@@ -87,13 +81,14 @@ impl Tui {
             color::Bg(color::White),
             color::Fg(color::Black),
             mode,
-            file_name,
+            status_bar.file_name,
             " ".repeat(padding as usize),
             cursor::Goto(width, height + 1),
             color::Fg(color::Reset),
             color::Bg(color::Reset),
         )
         .unwrap_or_default();
+        self.stdout.flush().unwrap_or_default();
     }
 
     /// Draw the line numbers

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,7 @@
 extern crate termion;
 use crate::editor::Mode;
 use crate::view::View;
+use std::collections::HashSet;
 use std::io::Write;
 use termion::clear;
 use termion::color;
@@ -133,6 +134,20 @@ impl Tui {
         self.draw_status_bar(name, mode, height as u16, width as u16);
         print!("{}", cursor::Goto(1, 1));
 
+        // move the cursor to the correct position
+        let (x, y) = view.cursor;
+        print!(
+            "{}",
+            cursor::Goto(x as u16 + LINE_NUMBER_WIDTH as u16 + 1, y as u16 + 1)
+        );
+        std::io::stdout().flush().unwrap_or_default();
+    }
+
+    pub fn refresh_lines(&mut self, view: &View, lines: HashSet<u16>) {
+        for line in lines {
+            self.draw_line_numbers((line + 1) as usize);
+            print!("{}", view.get_line(line as usize))
+        }
         // move the cursor to the correct position
         let (x, y) = view.cursor;
         print!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,6 +11,12 @@ use termion::raw::RawTerminal;
 
 const LINE_NUMBER_WIDTH: u16 = 4;
 
+pub struct StatusBar {
+    pub file_name: String,
+    pub mode: Mode,
+}
+
+
 /// Terminal User Interface
 /// Responsible for drawing the editor and handling user input using termion in raw mode
 pub struct Tui {

--- a/src/view.rs
+++ b/src/view.rs
@@ -140,14 +140,14 @@ impl View {
     /// world!
     /// ^ cursor is here
     /// ```
-    pub fn insert_new_line(&mut self) {
+    pub fn insert_new_line(&mut self) -> bool{
         let (rel_x, rel_y) = self.cursor;
         // Calculate the absolute position of the cursor in the file
         let (x, y) = (rel_x + self.start_col, rel_y + self.start_line);
         // Split the line at the cursor position
         self.file.split_line(y, x);
         // Navigate the cursor
-        self.navigate(-(x as isize), 1);
+        self.navigate(-(x as isize), 1)
     }
 
     pub fn delete(&mut self) {

--- a/src/view.rs
+++ b/src/view.rs
@@ -150,7 +150,8 @@ impl View {
         self.navigate(-(x as isize), 1)
     }
 
-    pub fn delete(&mut self) {
+    pub fn delete(&mut self) -> bool{
+        let scroll:bool;
         let (rel_x, rel_y) = self.cursor;
         // Calculate the absolute position of the cursor in the file
         let (x, y) = (rel_x + self.start_col, rel_y + self.start_line);
@@ -159,7 +160,7 @@ impl View {
 
         // Navigate the cursor
         if x > 0 {
-            self.navigate(-1, 0);
+            scroll = self.navigate(-1, 0);
         } else {
             // we go to the end of the previous line
             let line_len = self
@@ -167,8 +168,9 @@ impl View {
                 .get_line(y.saturating_sub(1))
                 .unwrap_or_default()
                 .len();
-            self.navigate(line_len as isize, -1);
+            scroll = self.navigate(line_len as isize, -1);
         }
+        scroll
     }
 
     pub fn dump_file(&self) -> String {

--- a/src/view.rs
+++ b/src/view.rs
@@ -118,13 +118,13 @@ impl View {
     /// # Insert a character at the cursor position
     /// This function will insert a character at the cursor position and move
     /// the cursor to the right.
-    pub fn insert(&mut self, c: char) {
+    pub fn insert(&mut self, c: char) -> bool{
         let (rel_x, rel_y) = self.cursor;
         // Calculate the absolute position of the cursor in the file
         let (x, y) = (rel_x + self.start_col, rel_y + self.start_line);
         // Insert the character at the cursor position
         self.file.insert(y, x, c);
-        self.navigate(1, 0);
+        self.navigate(1, 0)
     }
 
     /// # Insert a new line at the cursor position


### PR DESCRIPTION
Instead of refreshing all lines, the run loop in editor refresh only those changed :

- insert a char -> refresh the line
- insert a `'\n'` -> refresh tall lines below the current one
- delete a char -> refresh the line
- delete in column `0` -> refresh the line and the one above
- toogle mode -> refresh statusbar
- save -> refresh statusbar
- Commands (u,r) -> refresh all lines involved

Close #13
