### PR TITLE
feat: add rename mode

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -107,7 +107,6 @@ impl Command {
             Key::Char(c) => Ok(Command::Rename(Some(c))),
             _ => Err("Invalid command"),
         }
-        
     }
 
     /// Parse a character in insert mode

--- a/src/command.rs
+++ b/src/command.rs
@@ -11,8 +11,12 @@ pub enum Command {
     Move(isize, isize),
     /// Save the file
     Save,
+    /// Rename the file
+    Rename(Option<char>),
     /// Toggle mode
     ToggleMode,
+    /// Toggle rename
+    ToggleRename,
     /// Insert a character
     Insert(char),
     /// Delete a character
@@ -29,6 +33,7 @@ impl Command {
         match mode {
             Mode::Normal => Self::parse_normal_mode(key),
             Mode::Insert => Self::parse_insert_mode(key),
+            Mode::Rename => Self::parse_rename_mode(key),
         }
     }
 
@@ -71,6 +76,8 @@ impl Command {
             Key::Char('0') => Ok(Command::Move(-isize::MAX, 0)),
             // Save
             Key::Char('w') => Ok(Command::Save),
+            // Rename
+            Key::Char('R') => Ok(Command::ToggleRename),
             _ => Err("Invalid command"),
         }
     }
@@ -91,6 +98,16 @@ impl Command {
             Key::Down => Ok(Command::Move(0, 1)),
             _ => Err("Invalid command"),
         }
+    }
+
+    fn parse_rename_mode(key: Key) -> Result<Self, &'static str> {
+        match key {
+            Key::Backspace => Ok(Command::Rename(None)),
+            Key::Char('\n') => Ok(Command::ToggleMode),
+            Key::Char(c) => Ok(Command::Rename(Some(c))),
+            _ => Err("Invalid command"),
+        }
+        
     }
 
     /// Parse a character in insert mode

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -79,6 +79,7 @@ impl Tui {
         let mode: String = match status_bar.mode {
             Mode::Normal => "NORMAL ".to_string(),
             Mode::Insert => "INSERT ".to_string(),
+            Mode::Rename => "RENAME ".to_string(),
         };
         let padding = width
             - status_bar.file_name.len() as u16


### PR DESCRIPTION
 - Enter rename mode with `'R'` in Normal Mode
 - Exit with `\n`
 - Spaces and `'` are changed to `_`
 - You can't save a file with an empty name 
Closes: #15 